### PR TITLE
fix: improve enabling protocol without status pin

### DIFF
--- a/esphome/components/modem/__init__.py
+++ b/esphome/components/modem/__init__.py
@@ -13,10 +13,12 @@ from esphome.const import (
     CONF_DISABLED,
     CONF_ENABLE_ON_BOOT,
     CONF_ID,
+    CONF_INVERTED,
     CONF_MODEL,
     CONF_ON_CONNECT,
     CONF_ON_DISCONNECT,
     CONF_PASSWORD,
+    CONF_PIN,
     CONF_REBOOT_TIMEOUT,
     CONF_RX_BUFFER_SIZE,
     CONF_RX_PIN,
@@ -175,11 +177,17 @@ CONFIG_SCHEMA = cv.All(
             cv.Required(CONF_MODEL): cv.one_of(*MODEM_MODELS, upper=True),
             cv.Required(CONF_APN): cv.string,
             cv.Optional(CONF_STATUS_PIN): pins.gpio_input_pin_schema,
-            cv.Optional(CONF_POWER_PIN): pins.gpio_output_pin_schema,
-            cv.Optional(CONF_TON_PULSE_DELAY): cv.positive_time_period_milliseconds,
-            cv.Optional(CONF_TON_DELAY): cv.positive_time_period_milliseconds,
-            cv.Optional(CONF_TOFF_PULSE_DELAY): cv.positive_time_period_milliseconds,
-            cv.Optional(CONF_TOFF_DELAY): cv.positive_time_period_milliseconds,
+            cv.Optional(CONF_POWER_PIN): cv.maybe_simple_value(
+                {
+                    cv.Required(CONF_PIN): pins.gpio_output_pin_schema,
+                    cv.Optional(CONF_INVERTED, default=False): cv.boolean,
+                    cv.Optional(CONF_TON_PULSE_DELAY): cv.positive_time_period_milliseconds,
+                    cv.Optional(CONF_TON_DELAY): cv.positive_time_period_milliseconds,
+                    cv.Optional(CONF_TOFF_PULSE_DELAY): cv.positive_time_period_milliseconds,
+                    cv.Optional(CONF_TOFF_DELAY): cv.positive_time_period_milliseconds,
+                },
+                key=CONF_PIN,
+            ),
             cv.Optional(CONF_PIN_CODE): cv.string_strict,
             cv.Optional(CONF_USE_ADDRESS): cv.string,
             cv.Optional(CONF_INIT_AT): cv.All(cv.ensure_list(cv.string)),
@@ -246,26 +254,27 @@ def _final_validate(config):
     # if wifi_config := full_config.get(CONF_WIFI, None):
     #     if wifi_has_sta(wifi_config):
     #         raise cv.Invalid("Wi-Fi must be in AP-only mode when using a modem")
-    if config.get(CONF_POWER_PIN, None):
+    power_pin_config = config.get(CONF_POWER_PIN, None)
+    if power_pin_config:
         # if ton/off pulse delay options are defined, they overrides MODEM_MODELS_POWER
-        if ton_pulse_delay := config.get(CONF_TON_PULSE_DELAY, None):
+        if ton_pulse_delay := power_pin_config.get(CONF_TON_PULSE_DELAY, None):
             MODEM_MODELS_POWER[config[CONF_MODEL]][CONF_TON_PULSE_DELAY] = (
                 ton_pulse_delay
             )
-        if ton_delay := config.get(CONF_TON_DELAY, None):
+        if ton_delay := power_pin_config.get(CONF_TON_DELAY, None):
             MODEM_MODELS_POWER[config[CONF_MODEL]][CONF_TON_DELAY] = ton_delay
-        if toff_pulse_delay := config.get(CONF_TOFF_PULSE_DELAY, None):
+        if toff_pulse_delay := power_pin_config.get(CONF_TOFF_PULSE_DELAY, None):
             MODEM_MODELS_POWER[config[CONF_MODEL]][CONF_TOFF_PULSE_DELAY] = (
                 toff_pulse_delay
             )
-        if toff_delay := config.get(CONF_TOFF_DELAY, None):
+        if toff_delay := power_pin_config.get(CONF_TOFF_DELAY, None):
             MODEM_MODELS_POWER[config[CONF_MODEL]][CONF_TOFF_DELAY] = toff_delay
 
         if config[CONF_MODEL] not in MODEM_MODELS_POWER and not (
-            config.get(CONF_TON_PULSE_DELAY, None)
-            and config.get(CONF_TON_DELAY, None)
-            and config.get(CONF_TOFF_PULSE_DELAY, None)
-            and config.get(CONF_TOFF_DELAY, None)
+            power_pin_config.get(CONF_TON_PULSE_DELAY, None)
+            and power_pin_config.get(CONF_TON_DELAY, None)
+            and power_pin_config.get(CONF_TOFF_PULSE_DELAY, None)
+            and power_pin_config.get(CONF_TOFF_DELAY, None)
         ):
             raise cv.Invalid(
                 f"Modem model '{config[CONF_MODEL]}' has no known power specs. If using a power pin, '{CONF_TON_PULSE_DELAY}', '{CONF_TON_DELAY}', '{CONF_TOFF_PULSE_DELAY}', '{CONF_TOFF_DELAY}' options a required"
@@ -448,8 +457,10 @@ async def to_code(config):
         cg.add(var.set_status_pin(pin))
 
     if power_pin := config.get(CONF_POWER_PIN, None):
-        pin = await cg.gpio_pin_expression(power_pin)
+        pin = await cg.gpio_pin_expression(power_pin[CONF_PIN])
         cg.add(var.set_power_pin(pin))
+        if power_pin.get(CONF_INVERTED, False):
+            cg.add(var.set_power_pin_inverted(True))
 
     if rx_buffer_size := config.get(CONF_RX_BUFFER_SIZE, None):
         cg.add(var.set_rx_buffer_size(rx_buffer_size))

--- a/esphome/components/modem/__init__.py
+++ b/esphome/components/modem/__init__.py
@@ -181,9 +181,13 @@ CONFIG_SCHEMA = cv.All(
                 {
                     cv.Required(CONF_PIN): pins.gpio_output_pin_schema,
                     cv.Optional(CONF_INVERTED, default=False): cv.boolean,
-                    cv.Optional(CONF_TON_PULSE_DELAY): cv.positive_time_period_milliseconds,
+                    cv.Optional(
+                        CONF_TON_PULSE_DELAY
+                    ): cv.positive_time_period_milliseconds,
                     cv.Optional(CONF_TON_DELAY): cv.positive_time_period_milliseconds,
-                    cv.Optional(CONF_TOFF_PULSE_DELAY): cv.positive_time_period_milliseconds,
+                    cv.Optional(
+                        CONF_TOFF_PULSE_DELAY
+                    ): cv.positive_time_period_milliseconds,
                     cv.Optional(CONF_TOFF_DELAY): cv.positive_time_period_milliseconds,
                 },
                 key=CONF_PIN,

--- a/esphome/components/modem/__init__.py
+++ b/esphome/components/modem/__init__.py
@@ -459,8 +459,7 @@ async def to_code(config):
     if power_pin := config.get(CONF_POWER_PIN, None):
         pin = await cg.gpio_pin_expression(power_pin[CONF_PIN])
         cg.add(var.set_power_pin(pin))
-        if power_pin.get(CONF_INVERTED, False):
-            cg.add(var.set_power_pin_inverted(True))
+        cg.add(var.set_power_pin_inverted(power_pin.get(CONF_INVERTED)))
 
     if rx_buffer_size := config.get(CONF_RX_BUFFER_SIZE, None):
         cg.add(var.set_rx_buffer_size(rx_buffer_size))

--- a/esphome/components/modem/modem_component.cpp
+++ b/esphome/components/modem/modem_component.cpp
@@ -87,7 +87,7 @@ void ModemComponent::setup() {
 
   if (this->modem_handler->power_pin) {
     this->modem_handler->power_pin->setup();
-    this->modem_handler->power_pin->digital_write(true);
+    this->modem_handler->power_pin->digital_write(!this->modem_handler->power_pin_inverted);
   }
   if (this->modem_handler->status_pin) {
     this->modem_handler->status_pin->setup();
@@ -302,9 +302,9 @@ void ModemComponent::handle_state_enabling_() {
 }
 
 void ModemComponent::handle_state_powering_on_() {
-  this->modem_handler->power_pin->digital_write(false);
+  this->modem_handler->power_pin->digital_write(this->modem_handler->power_pin_inverted);
   delay(this->modem_handler->power_ton_pulse_delay);
-  this->modem_handler->power_pin->digital_write(true);
+  this->modem_handler->power_pin->digital_write(!this->modem_handler->power_pin_inverted);
   uint32_t loop_delay = this->modem_handler->power_ton_delay;
   this->loop_delay_(loop_delay);
   ESP_LOGD(TAG, "Modem ON in %.1fs...", float(loop_delay) / 1000);
@@ -313,9 +313,9 @@ void ModemComponent::handle_state_powering_on_() {
 }
 
 void ModemComponent::handle_state_powering_off_() {
-  this->modem_handler->power_pin->digital_write(false);
+  this->modem_handler->power_pin->digital_write(this->modem_handler->power_pin_inverted);
   delay(this->modem_handler->power_toff_pulse_delay);
-  this->modem_handler->power_pin->digital_write(true);
+  this->modem_handler->power_pin->digital_write(!this->modem_handler->power_pin_inverted);
   this->loop_delay_(this->modem_handler->power_toff_delay);
   ESP_LOGD(TAG, "Modem should be OFF in %.1fs...", float(this->modem_handler->power_toff_delay) / 1000);
 

--- a/esphome/components/modem/modem_component.cpp
+++ b/esphome/components/modem/modem_component.cpp
@@ -252,6 +252,13 @@ void ModemComponent::handle_state_enabling_() {
     this->modem_handler->modem_create_dte_dce(baud);
     this->modem_handler->dce->set_mode(esp_modem::modem_mode::AUTODETECT);
     bool success = this->modem_handler->dce->get_mode() != esp_modem::modem_mode::UNDEF;
+    // Sometimes the modem does not answer autobaud commands,
+    // so try sending an AT command to confirm it's responsive at this baud rate.
+    if (!success) {
+      App.feed_wdt();
+      auto result = this->modem_handler->send_at("AT");
+      success = result.esp_modem_command_result == command_result::OK;
+    }
     if (success) {
       this->modem_handler->current_baud_rate = baud;
       this->modem_restore_state_.baud_rate = baud;

--- a/esphome/components/modem/modem_component.cpp
+++ b/esphome/components/modem/modem_component.cpp
@@ -256,7 +256,7 @@ void ModemComponent::handle_state_enabling_() {
     // so try sending an AT command to confirm it's responsive at this baud rate.
     if (!success) {
       App.feed_wdt();
-      auto result = this->modem_handler->send_at("AT");
+      auto result = this->modem_handler->send_at("AT", 100);
       success = result.esp_modem_command_result == command_result::OK;
     }
     if (success) {

--- a/esphome/components/modem/modem_component.cpp
+++ b/esphome/components/modem/modem_component.cpp
@@ -277,7 +277,7 @@ void ModemComponent::handle_state_enabling_() {
       continue;
     }
     ESP_LOGV(TAG, "Modem ON. Autodetect mode: %s, baud: %d",
-              modem_mode_to_string(this->modem_handler->dce->get_mode()).c_str(), b);
+             modem_mode_to_string(this->modem_handler->dce->get_mode()).c_str(), b);
     auto mode = this->modem_handler->dce->get_mode();
     if (mode == modem_mode::CMUX_MANUAL_MODE || mode == modem_mode::DATA_MODE) {
       if (b != this->modem_handler->baud_rate) {

--- a/esphome/components/modem/modem_component.cpp
+++ b/esphome/components/modem/modem_component.cpp
@@ -273,30 +273,28 @@ void ModemComponent::handle_state_enabling_() {
   bauds.erase(std::unique(bauds.begin(), bauds.end()), bauds.end());
 
   for (int b : bauds) {
-    if (try_autobaud(b)) {
-      ESP_LOGV(TAG, "Modem ON. Autodetect mode: %s, baud: %d",
-               modem_mode_to_string(this->modem_handler->dce->get_mode()).c_str(), b);
-      auto mode = this->modem_handler->dce->get_mode();
-      if (mode == modem_mode::CMUX_MANUAL_MODE || mode == modem_mode::DATA_MODE) {
-        if (b != this->modem_handler->baud_rate) {
-          ESP_LOGI(TAG, "Modem connected, but baud rate has changed");
-          if (mode == modem_mode::CMUX_MANUAL_MODE) {
-            this->modem_handler->dce->set_mode(modem_mode::CMUX_MANUAL_EXIT);
-          } else {
-            this->modem_handler->dce->set_mode(modem_mode::COMMAND_MODE);
-          }
-          this->component_state_ = ModemComponentState::SYNCING;
-          return;
+    if (!try_autobaud(b)) {
+      continue;
+    }
+    ESP_LOGV(TAG, "Modem ON. Autodetect mode: %s, baud: %d",
+              modem_mode_to_string(this->modem_handler->dce->get_mode()).c_str(), b);
+    auto mode = this->modem_handler->dce->get_mode();
+    if (mode == modem_mode::CMUX_MANUAL_MODE || mode == modem_mode::DATA_MODE) {
+      if (b != this->modem_handler->baud_rate) {
+        ESP_LOGI(TAG, "Modem connected, but baud rate has changed");
+        if (mode == modem_mode::CMUX_MANUAL_MODE) {
+          this->modem_handler->dce->set_mode(modem_mode::CMUX_MANUAL_EXIT);
+        } else {
+          this->modem_handler->dce->set_mode(modem_mode::COMMAND_MODE);
         }
+      } else {
         // this->component_state_ = ModemComponentState::WAIT_IP;
         this->modem_handler->dce->set_mode(modem_mode::CMUX_MANUAL_EXIT);
         this->modem_handler->dce->set_mode(modem_mode::COMMAND_MODE);
-        this->component_state_ = ModemComponentState::SYNCING;
-        return;
       }
-      this->component_state_ = ModemComponentState::SYNCING;
-      return;
     }
+    this->component_state_ = ModemComponentState::SYNCING;
+    return;
   }
 
   if (this->modem_handler->power_pin) {

--- a/esphome/components/modem/modem_component.cpp
+++ b/esphome/components/modem/modem_component.cpp
@@ -55,7 +55,7 @@ AtCommandResult ModemComponent::send_at(const std::string &cmd, uint32_t timeout
 void ModemComponent::enable() {
   if (this->component_state_ == ModemComponentState::DISABLED) {
     ESP_LOGI(TAG, "Enabling modem");
-    set_timeout("modem timeout", this->timeout_, [this]() { this->abort_("Modem was not able to connect (timeout)"); });
+    set_timeout("modem_timeout", this->timeout_, [this]() { this->abort_("Modem was not able to connect (timeout)"); });
     // this->enable_loop();
     this->component_state_ = ModemComponentState::ENABLING;
   }
@@ -227,7 +227,7 @@ void ModemComponent::loop() {
 void ModemComponent::handle_state_disabled_() {
   // Just wait 'enable()'
   if (this->disable_wanted_) {
-    cancel_timeout("modem timeout");
+    cancel_timeout("modem_timeout");
     // this->disable_loop();
   } else {
     // Disable state was temporary (reset wanted)
@@ -303,25 +303,31 @@ void ModemComponent::handle_state_enabling_() {
 
 void ModemComponent::handle_state_powering_on_() {
   this->modem_handler->power_pin->digital_write(this->modem_handler->power_pin_inverted);
-  delay(this->modem_handler->power_ton_pulse_delay);
-  this->modem_handler->power_pin->digital_write(!this->modem_handler->power_pin_inverted);
-  uint32_t loop_delay = this->modem_handler->power_ton_delay;
-  this->loop_delay_(loop_delay);
-  ESP_LOGD(TAG, "Modem ON in %.1fs...", float(loop_delay) / 1000);
-
-  this->component_state_ = ModemComponentState::ENABLING;
+  // Use timeout to prevent blocking the main loop
+  set_timeout("modem_power_on", this->modem_handler->power_ton_pulse_delay, [this]() {
+    this->modem_handler->power_pin->digital_write(!this->modem_handler->power_pin_inverted);
+    uint32_t loop_delay = this->modem_handler->power_ton_delay;
+    this->enable_loop();
+    this->loop_delay_(loop_delay);
+    ESP_LOGD(TAG, "Modem ON in %.1fs...", float(this->modem_handler->power_ton_delay) / 1000);
+    this->component_state_ = ModemComponentState::ENABLING;
+  });
+  this->disable_loop();
 }
 
 void ModemComponent::handle_state_powering_off_() {
   this->modem_handler->power_pin->digital_write(this->modem_handler->power_pin_inverted);
-  delay(this->modem_handler->power_toff_pulse_delay);
-  this->modem_handler->power_pin->digital_write(!this->modem_handler->power_pin_inverted);
-  this->loop_delay_(this->modem_handler->power_toff_delay);
-  ESP_LOGD(TAG, "Modem should be OFF in %.1fs...", float(this->modem_handler->power_toff_delay) / 1000);
-
-  this->component_state_ = ModemComponentState::DISABLED;
-  this->modem_restore_state_.baud_rate = 0;
-  this->pref_.save(&this->modem_restore_state_);
+  // Use timeout to prevent blocking the main loop
+  set_timeout("modem_power_off", this->modem_handler->power_toff_pulse_delay, [this]() {
+    this->modem_handler->power_pin->digital_write(!this->modem_handler->power_pin_inverted);
+    this->enable_loop();
+    this->loop_delay_(this->modem_handler->power_toff_delay);
+    ESP_LOGD(TAG, "Modem should be OFF in %.1fs...", float(this->modem_handler->power_toff_delay) / 1000);
+    this->component_state_ = ModemComponentState::DISABLED;
+    this->modem_restore_state_.baud_rate = 0;
+    this->pref_.save(&this->modem_restore_state_);
+  });
+  this->disable_loop();
 }
 
 void ModemComponent::handle_state_syncing_() {
@@ -438,7 +444,7 @@ void ModemComponent::handle_state_wait_ip_() {
 }
 
 void ModemComponent::handle_state_connected_() {
-  cancel_timeout("modem timeout");
+  cancel_timeout("modem_timeout");
   if (!this->modem_handler->network_infos.got_ip) {
     ESP_LOGW(TAG, "Lost IP");
     this->component_state_ = ModemComponentState::DISCONNECTED;

--- a/esphome/components/modem/modem_component.h
+++ b/esphome/components/modem/modem_component.h
@@ -50,6 +50,7 @@ class ModemComponent : public Component {
   void set_baud_rate(int baud_rate) { this->modem_handler->baud_rate = baud_rate; }
   void set_model(const std::string &model) { this->modem_handler->model = model; }
   void set_power_pin(GPIOPin *power_pin) { this->modem_handler->power_pin = power_pin; }
+  void set_power_pin_inverted(bool inverted) { this->modem_handler->power_pin_inverted = inverted; }
   void set_power_ton_pulse_delay(uint32_t ton_pulse_delay) {
     this->modem_handler->power_ton_pulse_delay = ton_pulse_delay;
   }

--- a/esphome/components/modem/modem_handler.cpp
+++ b/esphome/components/modem/modem_handler.cpp
@@ -183,7 +183,7 @@ void ModemHandler::send_init_at() {
   if (this->rts_pin != nullptr && this->cts_pin != nullptr) {
     // Send AT command to setup flow control
     App.feed_wdt();
-    if (this->dce->set_flow_control(2,2) != command_result::OK) {
+    if (this->dce->set_flow_control(2, 2) != command_result::OK) {
       ESP_LOGE(TAG, "Failed to set modem flow control to RTS/CTS.");
       return;
     }

--- a/esphome/components/modem/modem_handler.cpp
+++ b/esphome/components/modem/modem_handler.cpp
@@ -50,7 +50,7 @@ void ModemHandler::modem_create_dte_dce(int baud_rate) {
     dte_config.uart_config.baud_rate = baud_rate;
   }
   if (this->rts_pin != nullptr && this->cts_pin != nullptr) {
-    ESP_LOGD(TAG, "Using RTS/CTS flow control");
+    ESP_LOGD(TAG, "Using RTS/CTS hardware flow control");
     dte_config.uart_config.rts_io_num = this->rts_pin->get_pin();
     dte_config.uart_config.cts_io_num = this->cts_pin->get_pin();
     dte_config.uart_config.flow_control = ESP_MODEM_FLOW_CONTROL_HW;
@@ -180,6 +180,15 @@ void ModemHandler::modem_log_status() {
 }
 
 void ModemHandler::send_init_at() {
+  if (this->rts_pin != nullptr && this->cts_pin != nullptr) {
+    // Send AT command to setup flow control
+    App.feed_wdt();
+    if (this->dce->set_flow_control(2,2) != command_result::OK) {
+      ESP_LOGE(TAG, "Failed to set modem flow control to RTS/CTS.");
+      return;
+    }
+  }
+
   for (const auto &cmd : this->init_at_commands) {
     App.feed_wdt();
     AtCommandResult result = this->send_at(cmd);

--- a/esphome/components/modem/modem_handler.cpp
+++ b/esphome/components/modem/modem_handler.cpp
@@ -185,7 +185,6 @@ void ModemHandler::send_init_at() {
     App.feed_wdt();
     if (this->dce->set_flow_control(2, 2) != command_result::OK) {
       ESP_LOGE(TAG, "Failed to set modem flow control to RTS/CTS.");
-      return;
     }
   }
 

--- a/esphome/components/modem/modem_handler.h
+++ b/esphome/components/modem/modem_handler.h
@@ -43,6 +43,7 @@ class ModemHandler {
   uint32_t power_toff_pulse_delay;
   uint32_t power_toff_delay;
   GPIOPin *power_pin{nullptr};
+  bool power_pin_inverted{false};
   uint16_t tx_buffer_size = 512;
   uint16_t rx_buffer_size = 512;
   uint16_t dte_buffer_size = 512;


### PR DESCRIPTION
Sorry for the all-over-the-place PR. This PR includes both features and fixes:

### Power pin configuration
* Added support for configuring the modem power pin as an object, allowing specification of inversion (`inverted`). This enables users to handle modems with active-low (which was the default before) or active-high (which is the recommended setup for chips like SIM7070G).
* Moved the ON/OFF pulse/delay timings inside the object, since they are directly related to the power pin. This is kind of a breaking change, but I think it makes things clearer in the config since those configurations don't make any sense without a power pin defined. See the following example:
```yaml
power_pin:
    pin: GPIO19
    inverted: true
    ton_delay: 30s
```
* Updated power-on and power-off logic to use non-blocking timeouts to avoid blocking the main thread. I wanted to make the WDT happier.

### Hardware flow control fix
While stress-testing my HW flow setup I was observing some weird artifacts. It looks like in #4 I forgot to setup the modem side for RTS/CTS. I have now added the explicit AT command setup (internally `AT+IFC=2,2`) for hardware flow control during initialization.

### Modem enabling protocol
It looks like the ESP32 `modem_mode::AUTODETECT` was having issues detecting my SIM7070G. I have added a fallback sending a simple `AT` command if autobaud detection fails.

If you agree with these changes, I will  happily create a PR in your docs!