### PR TITLE
[modem] Poll for network attachment instead of single check

### DIFF
--- a/esphome/components/modem/modem_component.cpp
+++ b/esphome/components/modem/modem_component.cpp
@@ -335,7 +335,15 @@ ModemComponentState ModemComponent::handle_state_connecting_() {
   this->modem_handler->prepare_sim();
   this->modem_handler->dce->set_network_attachment_state(1);
 
-  this->modem_handler->dce->get_network_attachment_state(attachement_state);
+  for (int i = 0; i < 30; i++) {
+    this->modem_handler->dce->get_network_attachment_state(attachement_state);
+    if (attachement_state) {
+      ESP_LOGI(TAG, "Modem attached after %ds", i);
+      break;
+    }
+    App.feed_wdt();
+    delay(1000);  // NOLINT
+  }
 
   if (!attachement_state) {
     ESP_LOGW(TAG, "Modem not yet ready to connect");


### PR DESCRIPTION
Previously `handle_state_connecting_()` issued `set_network_attachment_state(1)` then immediately checked `get_network_attachment_state()`. 

If the modem had not yet attached (Which im seeing often on roaming or M2M SIMs that can take 5-30s to register), the function returned `MODEM_CONNECTING` which re-entered the handler — re-running `set_radio_state(1)`, `prepare_sim()`, and `set_network_attachment_state(1)` every ~4 seconds. This repeated re-initialization disrupted the modem's own attach state machine, causing unnecessary state resets (CONNECTING → ENABLING → CONNECTING) and extended time-to-IP.

Replace the single check with a 30-second polling loop that calls `get_network_attachment_state()` once per second, feeding the watchdog between polls. This gives slow-registering SIMs time to attach without re-running the full init sequence on every retry.

Tested on Kincony KC868-G1 (ESP32-S3 + SIM7600E) with an M2M SIM:
* Without fix: 42s boot-to-IP, 2 state machine cycles, state reset
* With fix:    single clean pass, "Modem attached after 2s", no churn

# What does this implement/fix?

Replaces the single get_network_attachment_state() call in handle_state_connecting_() with a 30-second polling loop. The previous behaviour re-ran set_radio_state(1), prepare_sim(), and set_network_attachment_state(1) every ~4 seconds while waiting for attachment, which disrupted the modem's own registration process — especially on roaming or M2M SIMs that can take 5–30 seconds to register. 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A (no user-facing config change) 

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
  # No config change required — existing modem configs benefit automatically.
  modem:                                
    model: SIM7600                                    
    tx_pin: GPIO10                                                                                                                                                                                      
    rx_pin: GPIO9                                
    apn: mm.apn    

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
